### PR TITLE
Add QueryType discriminated union with EventOnly and StateOnly variants

### DIFF
--- a/examples/backend/README.md
+++ b/examples/backend/README.md
@@ -61,30 +61,39 @@ The example shows different subscriber patterns:
 ```gleam
 // Real-time subscriber - gets all events immediately
 let realtime_queries = [
-  #(process.new_name("balance-realtime"), fn(aggregate_id, events) {
-    // Update balance immediately for WebSocket clients
-    broadcast_balance_update(aggregate_id, calculate_balance(events))
-  }),
+  eventsourcing.EventOnly(
+    name: process.new_name("balance-realtime"),
+    query: fn(aggregate_id, events) {
+      // Update balance immediately for WebSocket clients
+      broadcast_balance_update(aggregate_id, calculate_balance(events))
+    },
+  ),
 ]
 
-// Batch subscriber - processes events in batches for efficiency  
+// Batch subscriber - processes events in batches for efficiency
 let batch_queries = [
-  #(process.new_name("audit-batch"), fn(aggregate_id, events) {
-    // Process multiple events together for audit logging
-    batch_audit_events(aggregate_id, events)
-  }),
+  eventsourcing.EventOnly(
+    name: process.new_name("audit-batch"),
+    query: fn(aggregate_id, events) {
+      // Process multiple events together for audit logging
+      batch_audit_events(aggregate_id, events)
+    },
+  ),
 ]
 
 // Snapshot-aware subscriber - requests snapshots on startup
 let snapshot_queries = [
-  #(process.new_name("transaction-history"), fn(aggregate_id, events) {
-    // Request snapshot if this is the first event we're seeing
-    case is_first_event(aggregate_id) {
-      True -> request_snapshot(aggregate_id)
-      False -> Nil
-    }
-    update_transaction_history(aggregate_id, events)
-  }),
+  eventsourcing.EventOnly(
+    name: process.new_name("transaction-history"),
+    query: fn(aggregate_id, events) {
+      // Request snapshot if this is the first event we're seeing
+      case is_first_event(aggregate_id) {
+        True -> request_snapshot(aggregate_id)
+        False -> Nil
+      }
+      update_transaction_history(aggregate_id, events)
+    },
+  ),
 ]
 ```
 
@@ -102,15 +111,18 @@ eventsourcing.execute(
 
 // WebSocket service subscribes to events and broadcasts to clients
 let websocket_queries = [
-  #(process.new_name("websocket-broadcaster"), fn(aggregate_id, events) {
-    list.each(connected_clients, fn(client) {
-      case client.subscribed_accounts {
-        accounts if list.contains(accounts, aggregate_id) ->
-          websocket.send(client.connection, json.encode(events))
-        _ -> Nil
-      }
-    })
-  }),
+  eventsourcing.EventOnly(
+    name: process.new_name("websocket-broadcaster"),
+    query: fn(aggregate_id, events) {
+      list.each(connected_clients, fn(client) {
+        case client.subscribed_accounts {
+          accounts if list.contains(accounts, aggregate_id) ->
+            websocket.send(client.connection, json.encode(events))
+          _ -> Nil
+        }
+      })
+    },
+  ),
 ]
 ```
 

--- a/examples/backend/src/backend/services.gleam
+++ b/examples/backend/src/backend/services.gleam
@@ -88,9 +88,9 @@ pub fn start_command_processor(
       apply: banking.apply,
       empty_state: banking.UnopenedBankAccount,
       queries: [
-        #(
-          process.new_name("websocket-broadcaster"),
-          fn(
+        eventsourcing.EventOnly(
+          name: process.new_name("websocket-broadcaster"),
+          query: fn(
             account_id: String,
             events: List(eventsourcing.EventEnvelop(banking.Event)),
           ) -> Nil {

--- a/examples/frontend/README.md
+++ b/examples/frontend/README.md
@@ -61,30 +61,39 @@ The example shows different subscriber patterns:
 ```gleam
 // Real-time subscriber - gets all events immediately
 let realtime_queries = [
-  #(process.new_name("balance-realtime"), fn(aggregate_id, events) {
-    // Update balance immediately for WebSocket clients
-    broadcast_balance_update(aggregate_id, calculate_balance(events))
-  }),
+  eventsourcing.EventOnly(
+    name: process.new_name("balance-realtime"),
+    query: fn(aggregate_id, events) {
+      // Update balance immediately for WebSocket clients
+      broadcast_balance_update(aggregate_id, calculate_balance(events))
+    },
+  ),
 ]
 
-// Batch subscriber - processes events in batches for efficiency  
+// Batch subscriber - processes events in batches for efficiency
 let batch_queries = [
-  #(process.new_name("audit-batch"), fn(aggregate_id, events) {
-    // Process multiple events together for audit logging
-    batch_audit_events(aggregate_id, events)
-  }),
+  eventsourcing.EventOnly(
+    name: process.new_name("audit-batch"),
+    query: fn(aggregate_id, events) {
+      // Process multiple events together for audit logging
+      batch_audit_events(aggregate_id, events)
+    },
+  ),
 ]
 
 // Snapshot-aware subscriber - requests snapshots on startup
 let snapshot_queries = [
-  #(process.new_name("transaction-history"), fn(aggregate_id, events) {
-    // Request snapshot if this is the first event we're seeing
-    case is_first_event(aggregate_id) {
-      True -> request_snapshot(aggregate_id)
-      False -> Nil
-    }
-    update_transaction_history(aggregate_id, events)
-  }),
+  eventsourcing.EventOnly(
+    name: process.new_name("transaction-history"),
+    query: fn(aggregate_id, events) {
+      // Request snapshot if this is the first event we're seeing
+      case is_first_event(aggregate_id) {
+        True -> request_snapshot(aggregate_id)
+        False -> Nil
+      }
+      update_transaction_history(aggregate_id, events)
+    },
+  ),
 ]
 ```
 
@@ -102,15 +111,18 @@ eventsourcing.execute(
 
 // WebSocket service subscribes to events and broadcasts to clients
 let websocket_queries = [
-  #(process.new_name("websocket-broadcaster"), fn(aggregate_id, events) {
-    list.each(connected_clients, fn(client) {
-      case client.subscribed_accounts {
-        accounts if list.contains(accounts, aggregate_id) ->
-          websocket.send(client.connection, json.encode(events))
-        _ -> Nil
-      }
-    })
-  }),
+  eventsourcing.EventOnly(
+    name: process.new_name("websocket-broadcaster"),
+    query: fn(aggregate_id, events) {
+      list.each(connected_clients, fn(client) {
+        case client.subscribed_accounts {
+          accounts if list.contains(accounts, aggregate_id) ->
+            websocket.send(client.connection, json.encode(events))
+          _ -> Nil
+        }
+      })
+    },
+  ),
 ]
 ```
 

--- a/src/eventsourcing.gleam
+++ b/src/eventsourcing.gleam
@@ -86,9 +86,16 @@ pub type Apply(entity, event) =
 pub type Handle(entity, command, event, error) =
   fn(entity, command) -> Result(List(event), error)
 
-@internal
-pub type Query(event) =
-  fn(AggregateId, List(EventEnvelop(event))) -> Nil
+pub type QueryType(entity, event) {
+  EventOnly(
+    name: process.Name(QueryMessage(event)),
+    query: fn(AggregateId, List(EventEnvelop(event))) -> Nil,
+  )
+  StateOnly(
+    name: process.Name(StateQueryMessage(entity)),
+    query: fn(AggregateId, entity) -> Nil,
+  )
+}
 
 pub type QueryActor(event) {
   QueryActor(actor: process.Subject(QueryMessage(event)))
@@ -96,6 +103,10 @@ pub type QueryActor(event) {
 
 pub type QueryMessage(event) {
   ProcessEvents(aggregate_id: AggregateId, events: List(EventEnvelop(event)))
+}
+
+pub type StateQueryMessage(entity) {
+  ProcessState(aggregate_id: AggregateId, entity: entity)
 }
 
 pub type AggregateMessage(entity, command, event, error) {
@@ -199,7 +210,8 @@ pub opaque type EventSourcing(
       error,
       transaction_handle,
     ),
-    query_actors: List(process.Name(QueryMessage(event))),
+    event_query_actors: List(process.Name(QueryMessage(event))),
+    state_query_actors: List(process.Name(StateQueryMessage(entity))),
     handle: Handle(entity, command, event, error),
     apply: Apply(entity, event),
     empty_state: entity,
@@ -295,7 +307,7 @@ pub type AggregateActorState(
 /// let #(store, _) = memory_store.supervised(events_name, snapshot_name, static_supervisor.OneForOne)
 /// 
 /// // Then create event sourcing system
-/// let balance_query = #(process.new_name("balance_query"), fn(aggregate_id, events) { /* update read model */ })
+/// let balance_query = eventsourcing.EventOnly(name: process.new_name("balance_query"), query: fn(aggregate_id, events) { /* update read model */ })
 /// let assert Ok(spec) = eventsourcing.supervised(
 ///   name: process.new_name("eventsourcing_actor"),
 ///   eventstore: store,
@@ -319,17 +331,37 @@ pub fn supervised(
   handle handle: Handle(entity, command, event, error),
   apply apply: Apply(entity, event),
   empty_state empty_state: entity,
-  queries queries: List(#(process.Name(QueryMessage(event)), Query(event))),
+  queries queries: List(QueryType(entity, event)),
   snapshot_config snapshot_config: Option(SnapshotConfig),
 ) -> Result(supervision.ChildSpecification(static_supervisor.Supervisor), Nil) {
-  // Create a single coordinator that manages everything properly under supervision
-  let queries =
-    list.map(queries, fn(query) {
-      let #(name, query) = query
-      #(name, supervision.worker(fn() { start_query(name, query) }))
+  // Split queries by variant and create worker specs
+  let event_query_specs =
+    list.filter_map(queries, fn(q) {
+      case q {
+        EventOnly(name, query) ->
+          Ok(#(
+            name,
+            supervision.worker(fn() { start_event_query(name, query) }),
+          ))
+        _ -> Error(Nil)
+      }
     })
-  let names = list.map(queries, fn(query) { query.0 })
-  let specs = list.map(queries, fn(query) { query.1 })
+  let state_query_specs =
+    list.filter_map(queries, fn(q) {
+      case q {
+        StateOnly(name, query) ->
+          Ok(#(
+            name,
+            supervision.worker(fn() { start_state_query(name, query) }),
+          ))
+        _ -> Error(Nil)
+      }
+    })
+
+  let event_query_names = list.map(event_query_specs, fn(q) { q.0 })
+  let state_query_names = list.map(state_query_specs, fn(q) { q.0 })
+  let event_specs = list.map(event_query_specs, fn(q) { q.1 })
+  let state_specs = list.map(state_query_specs, fn(q) { q.1 })
 
   let eventsourcing_spec =
     supervision.worker(fn() {
@@ -337,7 +369,8 @@ pub fn supervised(
         name:,
         eventstore: eventstore,
         handle: handle,
-        query_actors: names,
+        event_query_actors: event_query_names,
+        state_query_actors: state_query_names,
         apply: apply,
         empty_state: empty_state,
         snapshot_config:,
@@ -348,7 +381,10 @@ pub fn supervised(
   let supervisor =
     static_supervisor.new(static_supervisor.OneForOne)
     |> static_supervisor.add(eventsourcing_spec)
-    |> list.fold(specs, _, fn(supervisor, spec) {
+    |> list.fold(event_specs, _, fn(supervisor, spec) {
+      static_supervisor.add(supervisor, spec)
+    })
+    |> list.fold(state_specs, _, fn(supervisor, spec) {
       static_supervisor.add(supervisor, spec)
     })
     |> static_supervisor.supervised()
@@ -436,7 +472,8 @@ fn start(
     transaction_handle,
   ),
   handle handle: Handle(entity, command, event, error),
-  query_actors query_actors,
+  event_query_actors event_query_actors,
+  state_query_actors state_query_actors,
   apply apply: Apply(entity, event),
   empty_state empty_state: entity,
   snapshot_config snapshot_config: Option(SnapshotConfig),
@@ -445,7 +482,8 @@ fn start(
 ) {
   actor.new(EventSourcing(
     event_store: eventstore,
-    query_actors:,
+    event_query_actors:,
+    state_query_actors:,
     handle: handle,
     apply: apply,
     empty_state: empty_state,
@@ -533,7 +571,8 @@ fn on_message(
     GetSystemStats(reply_to) -> {
       let stats =
         SystemStats(
-          query_actors_count: list.length(state.query_actors),
+          query_actors_count: list.length(state.event_query_actors)
+            + list.length(state.state_query_actors),
           total_commands_processed: state.commands_processed,
         )
 
@@ -647,11 +686,19 @@ fn execute_command(
       _ -> Ok(Nil)
     })
 
-    state.query_actors
+    state.event_query_actors
     |> list.each(fn(query) {
       process.send(
         process.named_subject(query),
         ProcessEvents(aggregate_id, commited_events),
+      )
+    })
+
+    state.state_query_actors
+    |> list.each(fn(query) {
+      process.send(
+        process.named_subject(query),
+        ProcessState(aggregate_id, aggregate.entity),
       )
     })
     Ok(Nil)
@@ -880,12 +927,32 @@ pub fn latest_snapshot(
   receiver
 }
 
-fn start_query(name: process.Name(QueryMessage(event)), query: Query(event)) {
+fn start_event_query(
+  name: process.Name(QueryMessage(event)),
+  query: fn(AggregateId, List(EventEnvelop(event))) -> Nil,
+) {
   actor.new(Nil)
   |> actor.on_message(fn(_, message) {
     case message {
       ProcessEvents(aggregate_id, events) -> {
         query(aggregate_id, events)
+        actor.continue(Nil)
+      }
+    }
+  })
+  |> actor.named(name)
+  |> actor.start()
+}
+
+fn start_state_query(
+  name: process.Name(StateQueryMessage(entity)),
+  query: fn(AggregateId, entity) -> Nil,
+) {
+  actor.new(Nil)
+  |> actor.on_message(fn(_, message) {
+    case message {
+      ProcessState(aggregate_id, entity) -> {
+        query(aggregate_id, entity)
         actor.continue(Nil)
       }
     }

--- a/test/eventsourcing_test.gleam
+++ b/test/eventsourcing_test.gleam
@@ -29,9 +29,15 @@ pub fn supervised_architecture_test() {
 
   let query_executed_subject = process.new_subject()
   let queries = [
-    #(process.new_name("query_actor"), fn(aggregate_id, events) {
-      process.send(query_executed_subject, #(aggregate_id, list.length(events)))
-    }),
+    eventsourcing.EventOnly(
+      name: process.new_name("query_actor"),
+      query: fn(aggregate_id, events) {
+        process.send(query_executed_subject, #(
+          aggregate_id,
+          list.length(events),
+        ))
+      },
+    ),
   ]
 
   let name = process.new_name("eventsourcing_actor")
@@ -86,9 +92,12 @@ pub fn basic_command_execution_test() {
 
   let query_results = process.new_subject()
   let queries = [
-    #(process.new_name("basic-commands-query"), fn(aggregate_id, events) {
-      process.send(query_results, #(aggregate_id, list.length(events)))
-    }),
+    eventsourcing.EventOnly(
+      name: process.new_name("basic-commands-query"),
+      query: fn(aggregate_id, events) {
+        process.send(query_results, #(aggregate_id, list.length(events)))
+      },
+    ),
   ]
 
   let name = process.new_name("basic-commands-eventsourcing")
@@ -154,9 +163,12 @@ pub fn basic_command_execution_with_response_test() {
 
   let query_results = process.new_subject()
   let queries = [
-    #(process.new_name("basic-commands-query"), fn(aggregate_id, events) {
-      process.send(query_results, #(aggregate_id, list.length(events)))
-    }),
+    eventsourcing.EventOnly(
+      name: process.new_name("basic-commands-query"),
+      query: fn(aggregate_id, events) {
+        process.send(query_results, #(aggregate_id, list.length(events)))
+      },
+    ),
   ]
 
   let name = process.new_name("basic-commands-eventsourcing")
@@ -416,34 +428,46 @@ pub fn multiple_query_actors_test() {
   let query3_results = process.new_subject()
 
   let queries = [
-    #(process.new_name("query1"), fn(aggregate_id, events) {
-      process.send(query1_results, #(
-        "query1",
-        aggregate_id,
-        list.length(events),
-      ))
-    }),
-    #(process.new_name("query2"), fn(aggregate_id, events) {
-      process.send(query1_results, #(
-        "query1",
-        aggregate_id,
-        list.length(events),
-      ))
-    }),
-    #(process.new_name("query3"), fn(aggregate_id, events) {
-      process.send(query2_results, #(
-        "query2",
-        aggregate_id,
-        list.length(events),
-      ))
-    }),
-    #(process.new_name("query4"), fn(aggregate_id, events) {
-      process.send(query3_results, #(
-        "query3",
-        aggregate_id,
-        list.length(events),
-      ))
-    }),
+    eventsourcing.EventOnly(
+      name: process.new_name("query1"),
+      query: fn(aggregate_id, events) {
+        process.send(query1_results, #(
+          "query1",
+          aggregate_id,
+          list.length(events),
+        ))
+      },
+    ),
+    eventsourcing.EventOnly(
+      name: process.new_name("query2"),
+      query: fn(aggregate_id, events) {
+        process.send(query1_results, #(
+          "query1",
+          aggregate_id,
+          list.length(events),
+        ))
+      },
+    ),
+    eventsourcing.EventOnly(
+      name: process.new_name("query3"),
+      query: fn(aggregate_id, events) {
+        process.send(query2_results, #(
+          "query2",
+          aggregate_id,
+          list.length(events),
+        ))
+      },
+    ),
+    eventsourcing.EventOnly(
+      name: process.new_name("query4"),
+      query: fn(aggregate_id, events) {
+        process.send(query3_results, #(
+          "query3",
+          aggregate_id,
+          list.length(events),
+        ))
+      },
+    ),
   ]
 
   let name = process.new_name("multi-query-eventsourcing")
@@ -567,9 +591,12 @@ pub fn multiple_aggregates_test() {
 
   let query_results = process.new_subject()
   let queries = [
-    #(process.new_name("multi-aggregate-query"), fn(aggregate_id, events) {
-      process.send(query_results, #(aggregate_id, list.length(events)))
-    }),
+    eventsourcing.EventOnly(
+      name: process.new_name("multi-aggregate-query"),
+      query: fn(aggregate_id, events) {
+        process.send(query_results, #(aggregate_id, list.length(events)))
+      },
+    ),
   ]
 
   let name = process.new_name("multi-aggregate-eventsourcing")
@@ -809,9 +836,9 @@ pub fn concurrent_operations_test() {
 
   let query_counter = process.new_subject()
   let queries = [
-    #(
-      process.new_name("concurrent-operations-query"),
-      fn(_aggregate_id, events) {
+    eventsourcing.EventOnly(
+      name: process.new_name("concurrent-operations-query"),
+      query: fn(_aggregate_id, events) {
         list.each(events, fn(_) { process.send(query_counter, 1) })
       },
     ),
@@ -852,6 +879,70 @@ pub fn concurrent_operations_test() {
   // Count processed events 
   let event_count = count_events(query_counter, 0, 10)
   assert event_count == 10
+}
+
+pub fn state_only_query_test() {
+  let events_actor_name = process.new_name("events_actor")
+  let snapshot_actor_name = process.new_name("snapshot_actor")
+  let #(eventstore, child_spec) =
+    memory_store.supervised(
+      events_actor_name,
+      snapshot_actor_name,
+      static_supervisor.OneForOne,
+    )
+
+  let assert Ok(_) =
+    static_supervisor.new(static_supervisor.OneForOne)
+    |> static_supervisor.add(child_spec)
+    |> static_supervisor.start()
+
+  let state_subject = process.new_subject()
+  let queries = [
+    eventsourcing.StateOnly(
+      name: process.new_name("state-query"),
+      query: fn(aggregate_id, entity: example_bank_account.BankAccount) {
+        process.send(state_subject, #(aggregate_id, entity))
+      },
+    ),
+  ]
+
+  let name = process.new_name("state-query-eventsourcing")
+  let assert Ok(eventsourcing_spec) =
+    eventsourcing.supervised(
+      name:,
+      eventstore:,
+      handle: example_bank_account.handle,
+      apply: example_bank_account.apply,
+      empty_state: example_bank_account.UnopenedBankAccount,
+      queries:,
+      snapshot_config: None,
+    )
+
+  let assert Ok(_supervisor) =
+    static_supervisor.new(static_supervisor.OneForOne)
+    |> static_supervisor.add(eventsourcing_spec)
+    |> static_supervisor.start()
+
+  let eventsourcing = process.named_subject(name)
+  process.sleep(100)
+
+  // Open account — state query should receive updated entity
+  eventsourcing.execute(
+    eventsourcing,
+    "state-test",
+    example_bank_account.OpenAccount("state-test"),
+  )
+  let assert Ok(#("state-test", example_bank_account.BankAccount(0.0))) =
+    process.receive(state_subject, 1000)
+
+  // Deposit — state query should receive entity with new balance
+  eventsourcing.execute(
+    eventsourcing,
+    "state-test",
+    example_bank_account.DepositMoney(250.0),
+  )
+  let assert Ok(#("state-test", example_bank_account.BankAccount(250.0))) =
+    process.receive(state_subject, 1000)
 }
 
 fn count_events(


### PR DESCRIPTION
Replace tuple-based query API with typed QueryType union, enabling queries that receive either events or the current aggregate state. Update all examples, tests, and docs to use the new API.